### PR TITLE
Release v1, with support for go modules and a slight interface change

### DIFF
--- a/cdb_test.go
+++ b/cdb_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"syscall"
 	"testing"
 	"time"
 
@@ -56,7 +55,7 @@ func TestClosesFile(t *testing.T) {
 	require.NoError(t, err)
 
 	err = f.Close()
-	assert.Equal(t, syscall.EINVAL, err)
+	assert.Error(t, err)
 }
 
 func BenchmarkGet(b *testing.B) {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/colinmarc/cdb
+
+require (
+	github.com/Pallinder/go-randomdata v1.1.0
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/Pallinder/go-randomdata v1.1.0 h1:gUubB1IEUliFmzjqjhf+bgkg1o6uoFIkRsP3VrhEcx8=
+github.com/Pallinder/go-randomdata v1.1.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/hash.go
+++ b/hash.go
@@ -1,48 +1,12 @@
 package cdb
 
-import (
-	"encoding/binary"
-)
+const start uint32 = 5381
 
-const start = 5381
-
-type cdbHash struct {
-	uint32
-}
-
-func newCDBHash() *cdbHash {
-	return &cdbHash{start}
-}
-
-func (h *cdbHash) Write(data []byte) (int, error) {
-	v := h.uint32
+func cdbHash(data []byte) uint32 {
+	v := start
 	for _, b := range data {
 		v = ((v << 5) + v) ^ uint32(b)
 	}
 
-	h.uint32 = v
-	return len(data), nil
-}
-
-func (h *cdbHash) Sum(b []byte) []byte {
-	digest := make([]byte, 4)
-	binary.LittleEndian.PutUint32(b, h.Sum32())
-
-	return append(b, digest...)
-}
-
-func (h *cdbHash) Sum32() uint32 {
-	return h.uint32
-}
-
-func (h *cdbHash) Reset() {
-	h.uint32 = start
-}
-
-func (h *cdbHash) Size() int {
-	return 4
-}
-
-func (h *cdbHash) BlockSize() int {
-	return 4
+	return v
 }

--- a/hash_test.go
+++ b/hash_test.go
@@ -7,11 +7,6 @@ import (
 )
 
 func TestHash(t *testing.T) {
-	h := newCDBHash()
-	h.Write([]byte("foo bar baz"))
-	assert.EqualValues(t, 776976811, h.Sum32())
-
-	h = newCDBHash()
-	h.Write([]byte("The quick brown fox jumped over the lazy dog"))
-	assert.EqualValues(t, 3538394712, h.Sum32())
+	assert.EqualValues(t, 776976811, cdbHash([]byte("foo bar baz")))
+	assert.EqualValues(t, 3538394712, cdbHash([]byte("The quick brown fox jumped over the lazy dog")))
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -18,6 +18,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func fnvHash(data []byte) uint32 {
+	h := fnv.New32a()
+	h.Write(data)
+	return h.Sum32()
+}
+
 func testWritesReadable(t *testing.T, writer *cdb.Writer) {
 	expected := make([][][]byte, 0, 100)
 	for i := 0; i < cap(expected); i++ {
@@ -57,7 +63,7 @@ func TestWritesReadableFnv(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
-	writer, err := cdb.NewWriter(f, fnv.New32a())
+	writer, err := cdb.NewWriter(f, fnvHash)
 	require.NoError(t, err)
 	require.NotNil(t, writer)
 
@@ -116,7 +122,7 @@ func TestWritesRandomFnv(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
-	writer, err := cdb.NewWriter(f, fnv.New32a())
+	writer, err := cdb.NewWriter(f, fnvHash)
 	require.NoError(t, err)
 	require.NotNil(t, writer)
 
@@ -159,7 +165,7 @@ func BenchmarkPutFnv(b *testing.B) {
 		os.Remove(f.Name())
 	}()
 
-	writer, err := cdb.NewWriter(f, fnv.New32a())
+	writer, err := cdb.NewWriter(f, fnvHash)
 	require.NoError(b, err)
 
 	benchmarkPut(b, writer)


### PR DESCRIPTION
With the change in New from hash.Hash32 to func([]byte) uint32,
gets are now threadsafe if the underlying io.ReaderAt is.